### PR TITLE
fix: toast color by inline style

### DIFF
--- a/src/components/Toast.svelte
+++ b/src/components/Toast.svelte
@@ -16,13 +16,9 @@
   });
 </script>
 
-<div class="fixed bottom-4 right-4 space-y-2">
+<div class="toast">
   {#each toasts as toast}
-    <div
-      class="alert alert-{toast.status}"
-      in:fade|global={{ duration: 300 }}
-      out:fade|global={{ duration: 300 }}
-    >
+    <div class="alert alert-{toast.status}">
       <div>
         <span>{toast.message}</span>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,11 +1,14 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 @plugin "daisyui" {
-  themes: light --default, dark --prefersdark;
+  themes:
+    light --default,
+    dark --prefersdark;
 }
+@source inline("alert-{info,success,error}");
 
 /* NTSD Light Theme - Exact colors from daisyui-ntsd theme.ts */
 @plugin "daisyui/theme" {
-  name: "light";
+  name: 'light';
   default: true;
   prefersdark: false;
   color-scheme: light;
@@ -14,35 +17,35 @@
   --color-base-200: #fbfbff;
   --color-base-300: #eeeeff;
   --color-base-content: #000000;
-  
+
   --color-primary: #3b5bfb;
   --color-primary-content: #ffffff;
-  
+
   --color-secondary: #5b7292;
   --color-secondary-content: #ffffff;
-  
+
   --color-accent: #67cba0;
   --color-accent-content: #ffffff;
-  
+
   --color-neutral: #6b7280;
   --color-neutral-content: #ffffff;
-  
+
   --color-error: #e24056;
   --color-error-content: #ffffff;
 
   --radius-selector: 0rem;
   --radius-field: 0rem;
   --radius-box: 0rem;
-  
+
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
-  
+
   --border: 1px;
 }
 
 /* NTSD Dark Theme - Exact colors from daisyui-ntsd theme.ts */
 @plugin "daisyui/theme" {
-  name: "dark";
+  name: 'dark';
   default: false;
   prefersdark: true;
   color-scheme: dark;
@@ -51,28 +54,28 @@
   --color-base-200: #191c22;
   --color-base-300: #0d1117;
   --color-base-content: #ffffff;
-  
+
   --color-primary: #6071ff;
   --color-primary-content: #ffffff;
-  
+
   --color-secondary: #7289aa;
   --color-secondary-content: #ffffff;
-  
+
   --color-accent: #80e5b8;
   --color-accent-content: #ffffff;
-  
+
   --color-neutral: #828997;
   --color-neutral-content: #ffffff;
-  
+
   --color-error: #ff5b6c;
   --color-error-content: #ffffff;
 
   --radius-selector: 0rem;
   --radius-field: 0rem;
   --radius-box: 0rem;
-  
+
   --size-selector: 0.25rem;
   --size-field: 0.25rem;
-  
+
   --border: 1px;
 }


### PR DESCRIPTION
The toast color bug after upgrading to Tailwind 4 and removing the safelist. Instead, it required using the inline style instead